### PR TITLE
fix: fixed code editor scrolling and tooltip hovering

### DIFF
--- a/frontend/src/core/panels/CodePanel.module.sass
+++ b/frontend/src/core/panels/CodePanel.module.sass
@@ -1,6 +1,10 @@
 .container
   padding: 0.25rem 0
 
+  height: 100%
+
+  :global(.cm-editor)
+    height: 100%
   :global(.cm-gutters),
   :global(.cm-activeLineGutter)
     background: #3D3D3D

--- a/frontend/src/core/panels/dockview.sass
+++ b/frontend/src/core/panels/dockview.sass
@@ -64,6 +64,23 @@
           border: 2px solid #000
           box-shadow: 2px 2px 0 0 #000
 
+          transition: ease-in-out 0.2s
+          box-shadow: 2px 2px 0 0 #000
+
+        .dv-active-tab
+          border-radius: 8px
+          background-color: #FF8637
+          font-weight: 600
+
+          .dv-default-tab-action
+            color: black
+
+          .dv-svg
+            height: 8px
+            width: 8px
+          border: 2px solid #000
+          box-shadow: 0px 0px 0 0 #000
+        
       .dv-content-container
         overflow: hidden
         background-color: #3D3D3D
@@ -79,7 +96,7 @@
     --dv-color-abyss-lighter: #2a2837
     --dv-color-abyss-accent: #FF8637
     --dv-color-abyss-primary-text: black
-    --dv-color-abyss-secondary-text: rgb(148, 151, 169)
+    --dv-color-abyss-secondary-text: rgb(0, 0, 0)
 
     //
     --dv-drag-over-border: 2px solid var(--dv-color-abyss-accent)
@@ -89,12 +106,13 @@
     //
     --dv-group-view-background-color: transparent
     //
-    --dv-tabs-and-actions-container-background-color: #FF8637
+    --dv-tabs-and-actions-container-background-color: #FFB270
+    --dv-tabs-and-actions-container-inactive-background-color: #FF8637
     //
     --dv-activegroup-visiblepanel-tab-background-color: var(--dv-tabs-and-actions-container-background-color)
-    --dv-activegroup-hiddenpanel-tab-background-color: var(--dv-tabs-and-actions-container-background-color)
-    --dv-inactivegroup-visiblepanel-tab-background-color: var(--dv-tabs-and-actions-container-background-color)
-    --dv-inactivegroup-hiddenpanel-tab-background-color: var(--dv-tabs-and-actions-container-background-color)
+    --dv-activegroup-hiddenpanel-tab-background-color: var(--dv-tabs-and-actions-container-inactive-background-color)
+    --dv-inactivegroup-visiblepanel-tab-background-color: var(--dv-tabs-and-actions-container-inactive-background-color)
+    --dv-inactivegroup-hiddenpanel-tab-background-color: var(--dv-tabs-and-actions-container-inactive-background-color)
     --dv-tab-divider-color: transparent
     //
     --dv-activegroup-visiblepanel-tab-color: var(--dv-color-abyss-primary-text)

--- a/frontend/src/core/sidebar/Sidebar.tsx
+++ b/frontend/src/core/sidebar/Sidebar.tsx
@@ -18,9 +18,7 @@ function SidebarItem(props: ParentProps<{ title: string }>) {
       </Accordion.Trigger>
 
       <Accordion.Content class={style.item_content}>
-        <div>
-          {props.children}
-        </div>
+        <div>{props.children}</div>
       </Accordion.Content>
     </Accordion.Item>
   );
@@ -47,7 +45,7 @@ export function Sidebar() {
             </svg>
           </li>
 
-          <Tooltip placement="bottom" openDelay={200}>
+          <Tooltip placement="bottom" openDelay={200} hoverableContent={false}>
             <Tooltip.Trigger
               as="button"
               class={style.nav_item}
@@ -93,7 +91,7 @@ export function Sidebar() {
             </svg>
           </li>
 
-          <Tooltip placement="bottom" openDelay={200}>
+          <Tooltip placement="bottom" openDelay={200} hoverableContent={false}>
             <Tooltip.Trigger
               as="button"
               class={style.nav_item}
@@ -134,9 +132,7 @@ export function Sidebar() {
             DEPENDENCIES
           </SidebarItem>
 
-          <SidebarItem title="Features">
-            FEATURES
-          </SidebarItem>
+          <SidebarItem title="Features">FEATURES</SidebarItem>
         </Accordion>
       </div>
     </div>


### PR DESCRIPTION
Added simple fixes for code editor vertical scrolling and tooltip hovering
Now the code editor scrolls uses the whole height.
Hovering a tooltip doesn't keep the tooltip enabled.
Changed colors in tabs to be more intuitive.