### PR TITLE
Fixes issue #12 - Change WebSocket auth 

### DIFF
--- a/backend/src/ws/handlers.rs
+++ b/backend/src/ws/handlers.rs
@@ -53,7 +53,7 @@ fn parse_protocol_header(
         .filter(|c| !c.is_whitespace())
         .collect::<String>();
 
-    let elements = header.split(",").into_iter().collect::<Vec<&str>>();
+    let elements = header.splitn(2, ",").into_iter().collect::<Vec<&str>>();
 
     for elem in elements {
         let value = elem.splitn(2, ".").collect::<Vec<&str>>();

--- a/backend/src/ws/handlers.rs
+++ b/backend/src/ws/handlers.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use actix_error_proc::{proof_route, HttpResult};
 use actix_web::{web, HttpRequest};
 
@@ -13,12 +11,16 @@ use crate::ws::websocket::RgWebsocket;
 async fn websocket(
     req: HttpRequest,
     stream: web::Payload,
-    data: web::Data<Arc<AppState>>,
+    data: web::Data<AppState>,
 ) -> HttpResult<HttpErrors> {
-    let user_info = jwt::get_user_info(&req)?;
+    let (protocols, key_val) = parse_protocol_header(&req)?;
+    let Some(auth) = key_val.iter().find(|(auth, _)| auth == "auth") else {
+        return Err(HttpErrors::NoTokenProvided);
+    };
+    let user_info = jwt::decode(&auth.1).ok_or(HttpErrors::InvalidJWT)?;
 
     let ws = RgWebsocket {
-        app_state: data.get_ref().clone(),
+        app_state: data.get_ref().clone().into(),
         user_info,
         access: ProjectAccess::None,
     };
@@ -34,4 +36,34 @@ async fn websocket(
     ws.start(session, stream);
 
     Ok(response)
+}
+
+fn parse_protocol_header(
+    req: &HttpRequest,
+) -> Result<(Vec<String>, Vec<(String, String)>), HttpErrors> {
+    let mut key_value: Vec<(String, String)> = vec![];
+    let mut protocols: Vec<String> = vec![];
+    let Some(header) = req.headers().get("sec-websocket-protocol") else {
+        return Err(HttpErrors::NoTokenProvided);
+    };
+    let header = header
+        .to_str()
+        .map_err(|_| return HttpErrors::NoTokenProvided)?
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>();
+
+    let elements = header.split(",").into_iter().collect::<Vec<&str>>();
+
+    for elem in elements {
+        let value = elem.splitn(2, ".").collect::<Vec<&str>>();
+
+        if value.len() > 1 {
+            key_value.push((value[0].to_string(), value[1].to_string()));
+        } else {
+            protocols.push(value[0].to_string());
+        }
+    }
+
+    return Ok((protocols, key_value));
 }


### PR DESCRIPTION
The websocket endpoint now parses the sec-websocket-protocol header and uses a key-value based vector to find the jwt auth to use it as user data.
Some minor changes to the endpoint are included as well since it was not working correctly before